### PR TITLE
Make disconnect() handle closed connection

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3.7'
 services:
   redis:
     container_name: redis
@@ -7,3 +6,16 @@ services:
       - ./redisdata:/data
     ports:
       - '6379:6379'
+  reconnect-redis:
+    container_name: reconnect-redis
+    image: redis:6.2-alpine
+    volumes:
+      - ./redisdata:/data
+    command: --port 6380
+    ports:
+      - '6380:6380'
+    networks:
+      - reconnect
+
+networks:
+  reconnect:

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,9 @@
       "devDependencies": {
         "@integreat/ts-dev-setup": "^5.0.4",
         "@types/debug": "^4.1.12",
+        "@types/dockerode": "^3.3.31",
         "@types/sinon": "^17.0.2",
+        "dockerode": "^4.0.2",
         "integreat": "^1.5.4",
         "sinon": "^17.0.1"
       },
@@ -33,6 +35,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/@balena/dockerignore": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@balena/dockerignore/-/dockerignore-1.0.2.tgz",
+      "integrity": "sha512-wMue2Sy4GAVTk6Ic4tJVcnfdau+gx2EnG7S+uAEe+TWJFqE4YoWN4/H8MSLj4eYJKxGg26lZwboEniNiNwZQ6Q==",
+      "dev": true
     },
     "node_modules/@bcoe/v8-coverage": {
       "version": "0.2.3",
@@ -243,9 +251,10 @@
       }
     },
     "node_modules/@redis/client": {
-      "version": "1.5.13",
-      "resolved": "https://registry.npmjs.org/@redis/client/-/client-1.5.13.tgz",
-      "integrity": "sha512-epkUM9D0Sdmt93/8Ozk43PNjLi36RZzG+d/T1Gdu5AI8jvghonTeLYV69WVWdilvFo+PYxbP0TZ0saMvr6nscQ==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@redis/client/-/client-1.6.0.tgz",
+      "integrity": "sha512-aR0uffYI700OEEH4gYnitAnv3vzVGXCFvYfdpu/CJKvk4pHfLPEy/JSZyrpQ+15WhXe1yJRXLtfQ84s4mEXnPg==",
+      "license": "MIT",
       "dependencies": {
         "cluster-key-slot": "1.1.2",
         "generic-pool": "3.9.0",
@@ -264,25 +273,28 @@
       }
     },
     "node_modules/@redis/json": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/@redis/json/-/json-1.0.6.tgz",
-      "integrity": "sha512-rcZO3bfQbm2zPRpqo82XbW8zg4G/w4W3tI7X8Mqleq9goQjAGLL7q/1n1ZX4dXEAmORVZ4s1+uKLaUOg7LrUhw==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@redis/json/-/json-1.0.7.tgz",
+      "integrity": "sha512-6UyXfjVaTBTJtKNG4/9Z8PSpKE6XgSyEb8iwaqDcy+uKrd/DGYHTWkUdnQDyzm727V7p21WUMhsqz5oy65kPcQ==",
+      "license": "MIT",
       "peerDependencies": {
         "@redis/client": "^1.0.0"
       }
     },
     "node_modules/@redis/search": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/@redis/search/-/search-1.1.6.tgz",
-      "integrity": "sha512-mZXCxbTYKBQ3M2lZnEddwEAks0Kc7nauire8q20oA0oA/LoA+E/b5Y5KZn232ztPb1FkIGqo12vh3Lf+Vw5iTw==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@redis/search/-/search-1.2.0.tgz",
+      "integrity": "sha512-tYoDBbtqOVigEDMAcTGsRlMycIIjwMCgD8eR2t0NANeQmgK/lvxNAvYyb6bZDD4frHRhIHkJu2TBRvB0ERkOmw==",
+      "license": "MIT",
       "peerDependencies": {
         "@redis/client": "^1.0.0"
       }
     },
     "node_modules/@redis/time-series": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@redis/time-series/-/time-series-1.0.5.tgz",
-      "integrity": "sha512-IFjIgTusQym2B5IZJG3XKr5llka7ey84fw/NOYqESP5WUfQs9zz1ww/9+qoz4ka/S6KcGBodzlCeZ5UImKbscg==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@redis/time-series/-/time-series-1.1.0.tgz",
+      "integrity": "sha512-c1Q99M5ljsIuc4YdaCwfUEXsofakb9c8+Zse2qxTadu8TalLXuAESzLvFAvNVbkmSlvlzIQOLpBCmWI9wTOt+g==",
+      "license": "MIT",
       "peerDependencies": {
         "@redis/client": "^1.0.0"
       }
@@ -364,6 +376,27 @@
         "@types/ms": "*"
       }
     },
+    "node_modules/@types/docker-modem": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/docker-modem/-/docker-modem-3.0.6.tgz",
+      "integrity": "sha512-yKpAGEuKRSS8wwx0joknWxsmLha78wNMe9R2S3UNsVOkZded8UqOrV8KoeDXoXsjndxwyF3eIhyClGbO1SEhEg==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*",
+        "@types/ssh2": "*"
+      }
+    },
+    "node_modules/@types/dockerode": {
+      "version": "3.3.31",
+      "resolved": "https://registry.npmjs.org/@types/dockerode/-/dockerode-3.3.31.tgz",
+      "integrity": "sha512-42R9eoVqJDSvVspV89g7RwRqfNExgievLNWoHkg7NoWIqAmavIbgQBb4oc0qRtHkxE+I3Xxvqv7qVXFABKPBTg==",
+      "dev": true,
+      "dependencies": {
+        "@types/docker-modem": "*",
+        "@types/node": "*",
+        "@types/ssh2": "*"
+      }
+    },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.5.tgz",
@@ -383,11 +416,13 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "15.12.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-15.12.5.tgz",
-      "integrity": "sha512-se3yX7UHv5Bscf8f1ERKvQOD6sTyycH3hdaoozvaLxgUiY5lIGEeH37AD0G0Qi9kPqihPn0HOfd2yaIEN9VwEg==",
+      "version": "18.19.64",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.64.tgz",
+      "integrity": "sha512-955mDqvO2vFf/oL7V3WiUtiz+BugyX8uVbaT2H8oj3+8dRyH2FLiNdowe7eNqRM7IOIZvzDH76EoAT+gwm6aIQ==",
       "dev": true,
-      "peer": true
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
     },
     "node_modules/@types/semver": {
       "version": "7.5.6",
@@ -409,6 +444,15 @@
       "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-8.1.2.tgz",
       "integrity": "sha512-9GcLXF0/v3t80caGs5p2rRfkB+a8VBGLJZVih6CNFkx8IZ994wiKKLSRs9nuFwk1HevWs/1mnUmkApGrSGsShA==",
       "dev": true
+    },
+    "node_modules/@types/ssh2": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@types/ssh2/-/ssh2-1.15.1.tgz",
+      "integrity": "sha512-ZIbEqKAsi5gj35y4P4vkJYly642wIbY6PqoN0xiyQGshKUGXR9WQjF/iF9mXBQ8uBKy3ezfsCkcoHKhd0BzuDA==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "^18.11.18"
+      }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "6.14.0",
@@ -752,6 +796,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/asn1": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
+      "integrity": "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==",
+      "dev": true,
+      "dependencies": {
+        "safer-buffer": "~2.1.0"
+      }
+    },
     "node_modules/ava": {
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/ava/-/ava-5.3.1.tgz",
@@ -866,6 +919,35 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "node_modules/bcrypt-pbkdf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+      "integrity": "sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==",
+      "dev": true,
+      "dependencies": {
+        "tweetnacl": "^0.14.3"
+      }
+    },
     "node_modules/binary-extensions": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
@@ -873,6 +955,17 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "dev": true,
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
       }
     },
     "node_modules/blueimp-md5": {
@@ -901,6 +994,40 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/buildcheck": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/buildcheck/-/buildcheck-0.0.6.tgz",
+      "integrity": "sha512-8f9ZJCUXyT1M35Jx7MkBgmBMo3oHTTBIPLiY9xyL0pl3T5RwcPEY8cUHr5LBNfu/fk6c2T4DJZuVM/8ZZT2D2A==",
+      "dev": true,
+      "optional": true,
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/c8": {
@@ -1010,6 +1137,12 @@
       "optionalDependencies": {
         "fsevents": "~2.3.2"
       }
+    },
+    "node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "dev": true
     },
     "node_modules/chunkd": {
       "version": "2.0.1",
@@ -1229,6 +1362,21 @@
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       }
     },
+    "node_modules/cpu-features": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/cpu-features/-/cpu-features-0.0.10.tgz",
+      "integrity": "sha512-9IkYqtX3YHPCzoVg1Py+o9057a3i0fp7S530UWokCSaFVTc7CwXPRiOjRjBQQ18ZCNafx78YfnG+HALxtVmOGA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "dependencies": {
+        "buildcheck": "~0.0.6",
+        "nan": "^2.19.0"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/create-require": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
@@ -1286,11 +1434,12 @@
       }
     },
     "node_modules/debug": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "license": "MIT",
       "dependencies": {
-        "ms": "2.1.2"
+        "ms": "^2.1.3"
       },
       "engines": {
         "node": ">=6.0"
@@ -1300,11 +1449,6 @@
           "optional": true
         }
       }
-    },
-    "node_modules/debug/node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "node_modules/deep-is": {
       "version": "0.1.4",
@@ -1317,6 +1461,7 @@
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
       "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -1349,6 +1494,35 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/docker-modem": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/docker-modem/-/docker-modem-5.0.3.tgz",
+      "integrity": "sha512-89zhop5YVhcPEt5FpUFGr3cDyceGhq/F9J+ZndQ4KfqNvfbJpPMfgeixFgUj5OjCYAboElqODxY5Z1EBsSa6sg==",
+      "dev": true,
+      "dependencies": {
+        "debug": "^4.1.1",
+        "readable-stream": "^3.5.0",
+        "split-ca": "^1.0.1",
+        "ssh2": "^1.15.0"
+      },
+      "engines": {
+        "node": ">= 8.0"
+      }
+    },
+    "node_modules/dockerode": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/dockerode/-/dockerode-4.0.2.tgz",
+      "integrity": "sha512-9wM1BVpVMFr2Pw3eJNXrYYt6DT9k0xMcsSCjtPvyQ+xa1iPg/Mo3T/gUcwI0B2cczqCeCYRPF8yFYDwtFXT0+w==",
+      "dev": true,
+      "dependencies": {
+        "@balena/dockerignore": "^1.0.2",
+        "docker-modem": "^5.0.3",
+        "tar-fs": "~2.0.1"
+      },
+      "engines": {
+        "node": ">= 8.0"
       }
     },
     "node_modules/doctrine": {
@@ -1386,6 +1560,15 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "dev": true
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+      "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+      "dev": true,
+      "dependencies": {
+        "once": "^1.4.0"
+      }
     },
     "node_modules/enhance-visitors": {
       "version": "1.0.0",
@@ -1823,6 +2006,13 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true
     },
+    "node_modules/fast-uri": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.3.tgz",
+      "integrity": "sha512-aLrHthzCjH5He4Z2H9YZ+v6Ujb9ocRuW6ZzkJQOrTxleEijANq4v1TsaPaVG1PZcuurEzrLcWRyYBYXD5cEiaw==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
     "node_modules/fastq": {
       "version": "1.13.0",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.13.0.tgz",
@@ -1931,6 +2121,12 @@
       "engines": {
         "node": ">=8.0.0"
       }
+    },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "dev": true
     },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
@@ -2075,6 +2271,26 @@
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true
     },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
     "node_modules/ignore": {
       "version": "5.2.4",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.4.tgz",
@@ -2168,38 +2384,40 @@
       "dev": true
     },
     "node_modules/integreat": {
-      "version": "1.5.4",
-      "resolved": "https://registry.npmjs.org/integreat/-/integreat-1.5.4.tgz",
-      "integrity": "sha512-4jdG6gc7UYM4A00YAy9xOR6IGrtZu28cuMxVkEJkuAT1qukUe2REwINecTQOzjubvW4sbotNeUErFVSSs8KO2w==",
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/integreat/-/integreat-1.5.10.tgz",
+      "integrity": "sha512-9ywqkxQUsh/SIvHtrZDtJv50S+UO+TxbZ9cF8snGk6ScazYJULSHY88qPKHcHNT7DMDbpgjHbFv6dpZWJwSpTg==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
-        "ajv": "^8.12.0",
+        "ajv": "^8.16.0",
         "cron-parser": "^4.9.0",
-        "debug": "^4.3.4",
+        "debug": "^4.3.5",
         "deepmerge-ts": "^5.1.0",
         "map-any": "^1.0.0",
-        "map-transform": "^1.3.0",
+        "map-transform": "^1.5.1",
         "ms": "^2.1.3",
-        "nanoid": "^5.0.4",
-        "p-limit": "^4.0.0",
+        "nanoid": "^5.0.7",
+        "p-limit": "^5.0.0",
         "p-pipe": "^4.0.0",
         "p-progress": "^1.0.0",
-        "rfdc": "^1.3.0"
+        "rfdc": "^1.4.1"
       },
       "engines": {
         "node": ">= 18"
       }
     },
     "node_modules/integreat/node_modules/ajv": {
-      "version": "8.12.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
-      "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "fast-deep-equal": "^3.1.1",
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
         "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2",
-        "uri-js": "^4.2.2"
+        "require-from-string": "^2.0.2"
       },
       "funding": {
         "type": "github",
@@ -2210,7 +2428,24 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/integreat/node_modules/p-limit": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-5.0.0.tgz",
+      "integrity": "sha512-/Eaoq+QyLSiXQ4lyYV23f14mZRQcXnxfHrN0vCai+ak9G0pp9iEQukIIZq5NccEvwRB8PUnZT0KsOoDCINS1qQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/irregular-plurals": {
       "version": "3.5.0",
@@ -2537,40 +2772,18 @@
       }
     },
     "node_modules/map-transform": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/map-transform/-/map-transform-1.3.0.tgz",
-      "integrity": "sha512-uLvUI2vJY4k99P/fsWe7DvELuww6mE5lQ2vNTvmVhPu3WYT13caC+vgoqANTQKOQDFv1wX+1nxRMqcgJxl43EA==",
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/map-transform/-/map-transform-1.5.3.tgz",
+      "integrity": "sha512-Zu6qOcLltAYwEg/RgeZGTEy3bwi12hIK37fWLqpIwl2NLFW94PZ6HcDjy5KNmWzpTQ2RXP/0S9up4MkX0GJMsA==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
-        "ajv": "^8.12.0",
         "deepmerge": "^4.3.1",
         "map-any": "^1.0.0"
       },
       "engines": {
         "node": ">= 14"
       }
-    },
-    "node_modules/map-transform/node_modules/ajv": {
-      "version": "8.12.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
-      "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
-      "dev": true,
-      "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2",
-        "uri-js": "^4.2.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/map-transform/node_modules/json-schema-traverse": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "dev": true
     },
     "node_modules/matcher": {
       "version": "5.0.0",
@@ -2679,16 +2892,28 @@
         "node": "*"
       }
     },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "dev": true
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+    },
+    "node_modules/nan": {
+      "version": "2.22.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.22.0.tgz",
+      "integrity": "sha512-nbajikzWTMwsW+eSsNm3QwlOs7het9gGJU5dDZzRTQGk03vyBOauxgI4VakDzE0PtsGTmXPsXTbbjVhRwR5mpw==",
+      "dev": true,
+      "optional": true
     },
     "node_modules/nanoid": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.0.4.tgz",
-      "integrity": "sha512-vAjmBf13gsmhXSgBrtIclinISzFFy22WwCYoyilZlsrRXNIHSwgFQ1bEdjRwMT3aoadeIF6HMuDRlOxzfXV8ig==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.0.8.tgz",
+      "integrity": "sha512-TcJPw+9RV9dibz1hHUzlLVy8N4X9TnwirAjrU08Juo6BNKggzVfP2ZJ/3ZUSq15Xl5i85i+Z89XBO90pB2PghQ==",
       "dev": true,
       "funding": [
         {
@@ -2696,6 +2921,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "bin": {
         "nanoid": "bin/nanoid.js"
       },
@@ -3175,6 +3401,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/pump": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.2.tgz",
+      "integrity": "sha512-tUPXtzlGM8FE3P0ZL6DVs/3P58k9nk8/jZeQCurTJylQA8qFYzHFfhBJkuqyE0FifOsQ0uKWekiZ5g8wtr28cw==",
+      "dev": true,
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
@@ -3204,6 +3440,20 @@
         }
       ]
     },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dev": true,
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/readdirp": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
@@ -3217,16 +3467,20 @@
       }
     },
     "node_modules/redis": {
-      "version": "4.6.12",
-      "resolved": "https://registry.npmjs.org/redis/-/redis-4.6.12.tgz",
-      "integrity": "sha512-41Xuuko6P4uH4VPe5nE3BqXHB7a9lkFL0J29AlxKaIfD6eWO8VO/5PDF9ad2oS+mswMsfFxaM5DlE3tnXT+P8Q==",
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/redis/-/redis-4.7.0.tgz",
+      "integrity": "sha512-zvmkHEAdGMn+hMRXuMBtu4Vo5P6rHQjLoHftu+lBqq8ZTA3RCVC/WzD790bkKKiNFp7d5/9PcSD19fJyyRvOdQ==",
+      "license": "MIT",
+      "workspaces": [
+        "./packages/*"
+      ],
       "dependencies": {
         "@redis/bloom": "1.2.0",
-        "@redis/client": "1.5.13",
+        "@redis/client": "1.6.0",
         "@redis/graph": "1.1.1",
-        "@redis/json": "1.0.6",
-        "@redis/search": "1.1.6",
-        "@redis/time-series": "1.0.5"
+        "@redis/json": "1.0.7",
+        "@redis/search": "1.2.0",
+        "@redis/time-series": "1.1.0"
       }
     },
     "node_modules/regexp-tree": {
@@ -3264,6 +3518,7 @@
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3313,10 +3568,11 @@
       }
     },
     "node_modules/rfdc": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.3.0.tgz",
-      "integrity": "sha512-V2hovdzFbOi77/WajaSMXk2OLm+xNIeQdMMuB7icj7bk6zi2F8GGAxigcnDFpJHbNyNcgyJDiP+8nOrY5cZGrA==",
-      "dev": true
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
+      "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/rimraf": {
       "version": "3.0.2",
@@ -3356,6 +3612,26 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
     "node_modules/safe-regex": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-2.1.1.tgz",
@@ -3364,6 +3640,12 @@
       "dependencies": {
         "regexp-tree": "~0.1.1"
       }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true
     },
     "node_modules/semver": {
       "version": "7.5.4",
@@ -3477,11 +3759,35 @@
         "url": "https://github.com/chalk/slice-ansi?sponsor=1"
       }
     },
+    "node_modules/split-ca": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/split-ca/-/split-ca-1.0.1.tgz",
+      "integrity": "sha512-Q5thBSxp5t8WPTTJQS59LrGqOZqOsrhDGDVm8azCqIBjSBd7nd9o2PM+mDulQQkh8h//4U6hFZnc/mul8t5pWQ==",
+      "dev": true
+    },
     "node_modules/sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
       "dev": true
+    },
+    "node_modules/ssh2": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/ssh2/-/ssh2-1.16.0.tgz",
+      "integrity": "sha512-r1X4KsBGedJqo7h8F5c4Ybpcr5RjyP+aWIG007uBPRjmdQWfEiVLzSK71Zji1B9sKxwaCvD8y8cwSkYrlLiRRg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "dependencies": {
+        "asn1": "^0.2.6",
+        "bcrypt-pbkdf": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=10.16.0"
+      },
+      "optionalDependencies": {
+        "cpu-features": "~0.0.10",
+        "nan": "^2.20.0"
+      }
     },
     "node_modules/stack-utils": {
       "version": "2.0.6",
@@ -3502,6 +3808,15 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dev": true,
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
       }
     },
     "node_modules/string-width": {
@@ -3607,6 +3922,34 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/tar-fs": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.0.1.tgz",
+      "integrity": "sha512-6tzWDMeroL87uF/+lin46k+Q+46rAJ0SyPGz7OW7wTgblI273hsBqk2C1j0/xNadNLKDTUL9BukSjB7cwgmlPA==",
+      "dev": true,
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.0.0"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "dev": true,
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/temp-dir": {
@@ -3723,6 +4066,12 @@
         "node": ">=0.3.1"
       }
     },
+    "node_modules/tweetnacl": {
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==",
+      "dev": true
+    },
     "node_modules/type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -3769,6 +4118,12 @@
         "node": ">=14.17"
       }
     },
+    "node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true
+    },
     "node_modules/uri-js": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
@@ -3777,6 +4132,12 @@
       "dependencies": {
         "punycode": "^2.1.0"
       }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true
     },
     "node_modules/v8-compile-cache-lib": {
       "version": "3.0.1",
@@ -4046,6 +4407,12 @@
       "integrity": "sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==",
       "dev": true
     },
+    "@balena/dockerignore": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@balena/dockerignore/-/dockerignore-1.0.2.tgz",
+      "integrity": "sha512-wMue2Sy4GAVTk6Ic4tJVcnfdau+gx2EnG7S+uAEe+TWJFqE4YoWN4/H8MSLj4eYJKxGg26lZwboEniNiNwZQ6Q==",
+      "dev": true
+    },
     "@bcoe/v8-coverage": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
@@ -4204,9 +4571,9 @@
       "requires": {}
     },
     "@redis/client": {
-      "version": "1.5.13",
-      "resolved": "https://registry.npmjs.org/@redis/client/-/client-1.5.13.tgz",
-      "integrity": "sha512-epkUM9D0Sdmt93/8Ozk43PNjLi36RZzG+d/T1Gdu5AI8jvghonTeLYV69WVWdilvFo+PYxbP0TZ0saMvr6nscQ==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@redis/client/-/client-1.6.0.tgz",
+      "integrity": "sha512-aR0uffYI700OEEH4gYnitAnv3vzVGXCFvYfdpu/CJKvk4pHfLPEy/JSZyrpQ+15WhXe1yJRXLtfQ84s4mEXnPg==",
       "requires": {
         "cluster-key-slot": "1.1.2",
         "generic-pool": "3.9.0",
@@ -4220,21 +4587,21 @@
       "requires": {}
     },
     "@redis/json": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/@redis/json/-/json-1.0.6.tgz",
-      "integrity": "sha512-rcZO3bfQbm2zPRpqo82XbW8zg4G/w4W3tI7X8Mqleq9goQjAGLL7q/1n1ZX4dXEAmORVZ4s1+uKLaUOg7LrUhw==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@redis/json/-/json-1.0.7.tgz",
+      "integrity": "sha512-6UyXfjVaTBTJtKNG4/9Z8PSpKE6XgSyEb8iwaqDcy+uKrd/DGYHTWkUdnQDyzm727V7p21WUMhsqz5oy65kPcQ==",
       "requires": {}
     },
     "@redis/search": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/@redis/search/-/search-1.1.6.tgz",
-      "integrity": "sha512-mZXCxbTYKBQ3M2lZnEddwEAks0Kc7nauire8q20oA0oA/LoA+E/b5Y5KZn232ztPb1FkIGqo12vh3Lf+Vw5iTw==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@redis/search/-/search-1.2.0.tgz",
+      "integrity": "sha512-tYoDBbtqOVigEDMAcTGsRlMycIIjwMCgD8eR2t0NANeQmgK/lvxNAvYyb6bZDD4frHRhIHkJu2TBRvB0ERkOmw==",
       "requires": {}
     },
     "@redis/time-series": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@redis/time-series/-/time-series-1.0.5.tgz",
-      "integrity": "sha512-IFjIgTusQym2B5IZJG3XKr5llka7ey84fw/NOYqESP5WUfQs9zz1ww/9+qoz4ka/S6KcGBodzlCeZ5UImKbscg==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@redis/time-series/-/time-series-1.1.0.tgz",
+      "integrity": "sha512-c1Q99M5ljsIuc4YdaCwfUEXsofakb9c8+Zse2qxTadu8TalLXuAESzLvFAvNVbkmSlvlzIQOLpBCmWI9wTOt+g==",
       "requires": {}
     },
     "@sinonjs/commons": {
@@ -4316,6 +4683,27 @@
         "@types/ms": "*"
       }
     },
+    "@types/docker-modem": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/docker-modem/-/docker-modem-3.0.6.tgz",
+      "integrity": "sha512-yKpAGEuKRSS8wwx0joknWxsmLha78wNMe9R2S3UNsVOkZded8UqOrV8KoeDXoXsjndxwyF3eIhyClGbO1SEhEg==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*",
+        "@types/ssh2": "*"
+      }
+    },
+    "@types/dockerode": {
+      "version": "3.3.31",
+      "resolved": "https://registry.npmjs.org/@types/dockerode/-/dockerode-3.3.31.tgz",
+      "integrity": "sha512-42R9eoVqJDSvVspV89g7RwRqfNExgievLNWoHkg7NoWIqAmavIbgQBb4oc0qRtHkxE+I3Xxvqv7qVXFABKPBTg==",
+      "dev": true,
+      "requires": {
+        "@types/docker-modem": "*",
+        "@types/node": "*",
+        "@types/ssh2": "*"
+      }
+    },
     "@types/istanbul-lib-coverage": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.5.tgz",
@@ -4335,11 +4723,13 @@
       "dev": true
     },
     "@types/node": {
-      "version": "15.12.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-15.12.5.tgz",
-      "integrity": "sha512-se3yX7UHv5Bscf8f1ERKvQOD6sTyycH3hdaoozvaLxgUiY5lIGEeH37AD0G0Qi9kPqihPn0HOfd2yaIEN9VwEg==",
+      "version": "18.19.64",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.64.tgz",
+      "integrity": "sha512-955mDqvO2vFf/oL7V3WiUtiz+BugyX8uVbaT2H8oj3+8dRyH2FLiNdowe7eNqRM7IOIZvzDH76EoAT+gwm6aIQ==",
       "dev": true,
-      "peer": true
+      "requires": {
+        "undici-types": "~5.26.4"
+      }
     },
     "@types/semver": {
       "version": "7.5.6",
@@ -4361,6 +4751,15 @@
       "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-8.1.2.tgz",
       "integrity": "sha512-9GcLXF0/v3t80caGs5p2rRfkB+a8VBGLJZVih6CNFkx8IZ994wiKKLSRs9nuFwk1HevWs/1mnUmkApGrSGsShA==",
       "dev": true
+    },
+    "@types/ssh2": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@types/ssh2/-/ssh2-1.15.1.tgz",
+      "integrity": "sha512-ZIbEqKAsi5gj35y4P4vkJYly642wIbY6PqoN0xiyQGshKUGXR9WQjF/iF9mXBQ8uBKy3ezfsCkcoHKhd0BzuDA==",
+      "dev": true,
+      "requires": {
+        "@types/node": "^18.11.18"
+      }
     },
     "@typescript-eslint/eslint-plugin": {
       "version": "6.14.0",
@@ -4567,6 +4966,15 @@
       "integrity": "sha512-tLkvA81vQG/XqE2mjDkGQHoOINtMHtysSnemrmoGe6PydDPMRbVugqyk4A6V/WDWEfm3l+0d8anA9r8cv/5Jaw==",
       "dev": true
     },
+    "asn1": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
+      "integrity": "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==",
+      "dev": true,
+      "requires": {
+        "safer-buffer": "~2.1.0"
+      }
+    },
     "ava": {
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/ava/-/ava-5.3.1.tgz",
@@ -4651,11 +5059,37 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
     },
+    "base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true
+    },
+    "bcrypt-pbkdf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+      "integrity": "sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==",
+      "dev": true,
+      "requires": {
+        "tweetnacl": "^0.14.3"
+      }
+    },
     "binary-extensions": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
       "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
       "dev": true
+    },
+    "bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "dev": true,
+      "requires": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
     },
     "blueimp-md5": {
       "version": "2.19.0",
@@ -4681,6 +5115,23 @@
       "requires": {
         "fill-range": "^7.0.1"
       }
+    },
+    "buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "dev": true,
+      "requires": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
+    "buildcheck": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/buildcheck/-/buildcheck-0.0.6.tgz",
+      "integrity": "sha512-8f9ZJCUXyT1M35Jx7MkBgmBMo3oHTTBIPLiY9xyL0pl3T5RwcPEY8cUHr5LBNfu/fk6c2T4DJZuVM/8ZZT2D2A==",
+      "dev": true,
+      "optional": true
     },
     "c8": {
       "version": "8.0.1",
@@ -4753,6 +5204,12 @@
         "normalize-path": "~3.0.0",
         "readdirp": "~3.6.0"
       }
+    },
+    "chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "dev": true
     },
     "chunkd": {
       "version": "2.0.1",
@@ -4919,6 +5376,17 @@
       "integrity": "sha512-rcQ1bsQO9799wq24uE5AM2tAILy4gXGIK/njFWcVQkGNZ96edlpY+A7bjwvzjYvLDyzmG1MmMLZhpcsb+klNMQ==",
       "dev": true
     },
+    "cpu-features": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/cpu-features/-/cpu-features-0.0.10.tgz",
+      "integrity": "sha512-9IkYqtX3YHPCzoVg1Py+o9057a3i0fp7S530UWokCSaFVTc7CwXPRiOjRjBQQ18ZCNafx78YfnG+HALxtVmOGA==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "buildcheck": "~0.0.6",
+        "nan": "^2.19.0"
+      }
+    },
     "create-require": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
@@ -4964,18 +5432,11 @@
       }
     },
     "debug": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
       "requires": {
-        "ms": "2.1.2"
-      },
-      "dependencies": {
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-        }
+        "ms": "^2.1.3"
       }
     },
     "deep-is": {
@@ -5011,6 +5472,29 @@
         "path-type": "^4.0.0"
       }
     },
+    "docker-modem": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/docker-modem/-/docker-modem-5.0.3.tgz",
+      "integrity": "sha512-89zhop5YVhcPEt5FpUFGr3cDyceGhq/F9J+ZndQ4KfqNvfbJpPMfgeixFgUj5OjCYAboElqODxY5Z1EBsSa6sg==",
+      "dev": true,
+      "requires": {
+        "debug": "^4.1.1",
+        "readable-stream": "^3.5.0",
+        "split-ca": "^1.0.1",
+        "ssh2": "^1.15.0"
+      }
+    },
+    "dockerode": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/dockerode/-/dockerode-4.0.2.tgz",
+      "integrity": "sha512-9wM1BVpVMFr2Pw3eJNXrYYt6DT9k0xMcsSCjtPvyQ+xa1iPg/Mo3T/gUcwI0B2cczqCeCYRPF8yFYDwtFXT0+w==",
+      "dev": true,
+      "requires": {
+        "@balena/dockerignore": "^1.0.2",
+        "docker-modem": "^5.0.3",
+        "tar-fs": "~2.0.1"
+      }
+    },
     "doctrine": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
@@ -5037,6 +5521,15 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "dev": true
+    },
+    "end-of-stream": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+      "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+      "dev": true,
+      "requires": {
+        "once": "^1.4.0"
+      }
     },
     "enhance-visitors": {
       "version": "1.0.0",
@@ -5351,6 +5844,12 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true
     },
+    "fast-uri": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.3.tgz",
+      "integrity": "sha512-aLrHthzCjH5He4Z2H9YZ+v6Ujb9ocRuW6ZzkJQOrTxleEijANq4v1TsaPaVG1PZcuurEzrLcWRyYBYXD5cEiaw==",
+      "dev": true
+    },
     "fastq": {
       "version": "1.13.0",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.13.0.tgz",
@@ -5431,6 +5930,12 @@
         "cross-spawn": "^7.0.0",
         "signal-exit": "^3.0.2"
       }
+    },
+    "fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "dev": true
     },
     "fs.realpath": {
       "version": "1.0.0",
@@ -5535,6 +6040,12 @@
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true
     },
+    "ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "dev": true
+    },
     "ignore": {
       "version": "5.2.4",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.4.tgz",
@@ -5600,35 +6111,35 @@
       "dev": true
     },
     "integreat": {
-      "version": "1.5.4",
-      "resolved": "https://registry.npmjs.org/integreat/-/integreat-1.5.4.tgz",
-      "integrity": "sha512-4jdG6gc7UYM4A00YAy9xOR6IGrtZu28cuMxVkEJkuAT1qukUe2REwINecTQOzjubvW4sbotNeUErFVSSs8KO2w==",
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/integreat/-/integreat-1.5.10.tgz",
+      "integrity": "sha512-9ywqkxQUsh/SIvHtrZDtJv50S+UO+TxbZ9cF8snGk6ScazYJULSHY88qPKHcHNT7DMDbpgjHbFv6dpZWJwSpTg==",
       "dev": true,
       "requires": {
-        "ajv": "^8.12.0",
+        "ajv": "^8.16.0",
         "cron-parser": "^4.9.0",
-        "debug": "^4.3.4",
+        "debug": "^4.3.5",
         "deepmerge-ts": "^5.1.0",
         "map-any": "^1.0.0",
-        "map-transform": "^1.3.0",
+        "map-transform": "^1.5.1",
         "ms": "^2.1.3",
-        "nanoid": "^5.0.4",
-        "p-limit": "^4.0.0",
+        "nanoid": "^5.0.7",
+        "p-limit": "^5.0.0",
         "p-pipe": "^4.0.0",
         "p-progress": "^1.0.0",
-        "rfdc": "^1.3.0"
+        "rfdc": "^1.4.1"
       },
       "dependencies": {
         "ajv": {
-          "version": "8.12.0",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
-          "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+          "version": "8.17.1",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+          "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
           "dev": true,
           "requires": {
-            "fast-deep-equal": "^3.1.1",
+            "fast-deep-equal": "^3.1.3",
+            "fast-uri": "^3.0.1",
             "json-schema-traverse": "^1.0.0",
-            "require-from-string": "^2.0.2",
-            "uri-js": "^4.2.2"
+            "require-from-string": "^2.0.2"
           }
         },
         "json-schema-traverse": {
@@ -5636,6 +6147,15 @@
           "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
           "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
           "dev": true
+        },
+        "p-limit": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-5.0.0.tgz",
+          "integrity": "sha512-/Eaoq+QyLSiXQ4lyYV23f14mZRQcXnxfHrN0vCai+ak9G0pp9iEQukIIZq5NccEvwRB8PUnZT0KsOoDCINS1qQ==",
+          "dev": true,
+          "requires": {
+            "yocto-queue": "^1.0.0"
+          }
         }
       }
     },
@@ -5880,34 +6400,13 @@
       "integrity": "sha512-e/Og7gTAVi/9npRJYoz/8GqvlQrHJ+nSAUF6FbDKwra0vbEci0IrJk1eYy2SnPUfjq8oWBtMw2rvI0dQV0RlMg=="
     },
     "map-transform": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/map-transform/-/map-transform-1.3.0.tgz",
-      "integrity": "sha512-uLvUI2vJY4k99P/fsWe7DvELuww6mE5lQ2vNTvmVhPu3WYT13caC+vgoqANTQKOQDFv1wX+1nxRMqcgJxl43EA==",
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/map-transform/-/map-transform-1.5.3.tgz",
+      "integrity": "sha512-Zu6qOcLltAYwEg/RgeZGTEy3bwi12hIK37fWLqpIwl2NLFW94PZ6HcDjy5KNmWzpTQ2RXP/0S9up4MkX0GJMsA==",
       "dev": true,
       "requires": {
-        "ajv": "^8.12.0",
         "deepmerge": "^4.3.1",
         "map-any": "^1.0.0"
-      },
-      "dependencies": {
-        "ajv": {
-          "version": "8.12.0",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
-          "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
-          "dev": true,
-          "requires": {
-            "fast-deep-equal": "^3.1.1",
-            "json-schema-traverse": "^1.0.0",
-            "require-from-string": "^2.0.2",
-            "uri-js": "^4.2.2"
-          }
-        },
-        "json-schema-traverse": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-          "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-          "dev": true
-        }
       }
     },
     "matcher": {
@@ -5983,16 +6482,28 @@
         "brace-expansion": "^1.1.7"
       }
     },
+    "mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "dev": true
+    },
     "ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+    },
+    "nan": {
+      "version": "2.22.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.22.0.tgz",
+      "integrity": "sha512-nbajikzWTMwsW+eSsNm3QwlOs7het9gGJU5dDZzRTQGk03vyBOauxgI4VakDzE0PtsGTmXPsXTbbjVhRwR5mpw==",
+      "dev": true,
+      "optional": true
     },
     "nanoid": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.0.4.tgz",
-      "integrity": "sha512-vAjmBf13gsmhXSgBrtIclinISzFFy22WwCYoyilZlsrRXNIHSwgFQ1bEdjRwMT3aoadeIF6HMuDRlOxzfXV8ig==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.0.8.tgz",
+      "integrity": "sha512-TcJPw+9RV9dibz1hHUzlLVy8N4X9TnwirAjrU08Juo6BNKggzVfP2ZJ/3ZUSq15Xl5i85i+Z89XBO90pB2PghQ==",
       "dev": true
     },
     "natural-compare": {
@@ -6321,6 +6832,16 @@
         "parse-ms": "^3.0.0"
       }
     },
+    "pump": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.2.tgz",
+      "integrity": "sha512-tUPXtzlGM8FE3P0ZL6DVs/3P58k9nk8/jZeQCurTJylQA8qFYzHFfhBJkuqyE0FifOsQ0uKWekiZ5g8wtr28cw==",
+      "dev": true,
+      "requires": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
     "punycode": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
@@ -6333,6 +6854,17 @@
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
       "dev": true
     },
+    "readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dev": true,
+      "requires": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      }
+    },
     "readdirp": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
@@ -6343,16 +6875,16 @@
       }
     },
     "redis": {
-      "version": "4.6.12",
-      "resolved": "https://registry.npmjs.org/redis/-/redis-4.6.12.tgz",
-      "integrity": "sha512-41Xuuko6P4uH4VPe5nE3BqXHB7a9lkFL0J29AlxKaIfD6eWO8VO/5PDF9ad2oS+mswMsfFxaM5DlE3tnXT+P8Q==",
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/redis/-/redis-4.7.0.tgz",
+      "integrity": "sha512-zvmkHEAdGMn+hMRXuMBtu4Vo5P6rHQjLoHftu+lBqq8ZTA3RCVC/WzD790bkKKiNFp7d5/9PcSD19fJyyRvOdQ==",
       "requires": {
         "@redis/bloom": "1.2.0",
-        "@redis/client": "1.5.13",
+        "@redis/client": "1.6.0",
         "@redis/graph": "1.1.1",
-        "@redis/json": "1.0.6",
-        "@redis/search": "1.1.6",
-        "@redis/time-series": "1.0.5"
+        "@redis/json": "1.0.7",
+        "@redis/search": "1.2.0",
+        "@redis/time-series": "1.1.0"
       }
     },
     "regexp-tree": {
@@ -6411,9 +6943,9 @@
       "dev": true
     },
     "rfdc": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.3.0.tgz",
-      "integrity": "sha512-V2hovdzFbOi77/WajaSMXk2OLm+xNIeQdMMuB7icj7bk6zi2F8GGAxigcnDFpJHbNyNcgyJDiP+8nOrY5cZGrA==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
+      "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
       "dev": true
     },
     "rimraf": {
@@ -6434,6 +6966,12 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true
+    },
     "safe-regex": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-2.1.1.tgz",
@@ -6442,6 +6980,12 @@
       "requires": {
         "regexp-tree": "~0.1.1"
       }
+    },
+    "safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true
     },
     "semver": {
       "version": "7.5.4",
@@ -6520,11 +7064,29 @@
         "is-fullwidth-code-point": "^4.0.0"
       }
     },
+    "split-ca": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/split-ca/-/split-ca-1.0.1.tgz",
+      "integrity": "sha512-Q5thBSxp5t8WPTTJQS59LrGqOZqOsrhDGDVm8azCqIBjSBd7nd9o2PM+mDulQQkh8h//4U6hFZnc/mul8t5pWQ==",
+      "dev": true
+    },
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
       "dev": true
+    },
+    "ssh2": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/ssh2/-/ssh2-1.16.0.tgz",
+      "integrity": "sha512-r1X4KsBGedJqo7h8F5c4Ybpcr5RjyP+aWIG007uBPRjmdQWfEiVLzSK71Zji1B9sKxwaCvD8y8cwSkYrlLiRRg==",
+      "dev": true,
+      "requires": {
+        "asn1": "^0.2.6",
+        "bcrypt-pbkdf": "^1.0.2",
+        "cpu-features": "~0.0.10",
+        "nan": "^2.20.0"
+      }
     },
     "stack-utils": {
       "version": "2.0.6",
@@ -6541,6 +7103,15 @@
           "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
           "dev": true
         }
+      }
+    },
+    "string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "~5.2.0"
       }
     },
     "string-width": {
@@ -6619,6 +7190,31 @@
         "has-flag": "^4.0.0"
       }
     },
+    "tar-fs": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.0.1.tgz",
+      "integrity": "sha512-6tzWDMeroL87uF/+lin46k+Q+46rAJ0SyPGz7OW7wTgblI273hsBqk2C1j0/xNadNLKDTUL9BukSjB7cwgmlPA==",
+      "dev": true,
+      "requires": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.0.0"
+      }
+    },
+    "tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "dev": true,
+      "requires": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      }
+    },
     "temp-dir": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-3.0.0.tgz",
@@ -6693,6 +7289,12 @@
         }
       }
     },
+    "tweetnacl": {
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==",
+      "dev": true
+    },
     "type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -6720,6 +7322,12 @@
       "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
       "dev": true
     },
+    "undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true
+    },
     "uri-js": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
@@ -6728,6 +7336,12 @@
       "requires": {
         "punycode": "^2.1.0"
       }
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true
     },
     "v8-compile-cache-lib": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,9 @@
   "devDependencies": {
     "@integreat/ts-dev-setup": "^5.0.4",
     "@types/debug": "^4.1.12",
+    "@types/dockerode": "^3.3.31",
     "@types/sinon": "^17.0.2",
+    "dockerode": "^4.0.2",
     "integreat": "^1.5.4",
     "sinon": "^17.0.1"
   }

--- a/src/connect.test.ts
+++ b/src/connect.test.ts
@@ -170,6 +170,7 @@ test('should reconnect when connection is expired', async (t) => {
   const clientWithQuit = {
     ...client,
     quit: sinon.stub().resolves(),
+    isOpen: true,
   }
   const createClient = sinon.stub().returns(client)
   const options = { redis: { uri: 'redis://localhost:6379' } }

--- a/src/connect.test.ts
+++ b/src/connect.test.ts
@@ -170,7 +170,7 @@ test('should reconnect when connection is expired', async (t) => {
   const clientWithQuit = {
     ...client,
     quit: sinon.stub().resolves(),
-    isOpen: true,
+    isReady: true,
   }
   const createClient = sinon.stub().returns(client)
   const options = { redis: { uri: 'redis://localhost:6379' } }

--- a/src/disconnect.test.ts
+++ b/src/disconnect.test.ts
@@ -9,7 +9,7 @@ import disconnect from './disconnect.js'
 test('should call quit on redis client', async (t) => {
   const redisClient = {
     quit: sinon.stub().resolves(),
-    isOpen: true,
+    isReady: true,
   }
   const connection = {
     status: 'ok',
@@ -22,10 +22,10 @@ test('should call quit on redis client', async (t) => {
   t.is(connection.redisClient, null)
 })
 
-test('should handle that quit throws even though client reports isOpen', async (t) => {
+test('should handle that quit throws even though client reports isReady', async (t) => {
   const redisClient = {
     quit: sinon.stub().throws('Error'),
-    isOpen: true,
+    isReady: true,
   }
   const connection = {
     status: 'ok',
@@ -38,10 +38,10 @@ test('should handle that quit throws even though client reports isOpen', async (
   t.is(connection.redisClient, null)
 })
 
-test('should not call quit on redis client when the client is already closed', async (t) => {
+test('should not call quit on redis client when the client is already closed, aka. client.isReady == false', async (t) => {
   const redisClient = {
     quit: sinon.stub().resolves(),
-    isOpen: false,
+    isReady: false,
   }
   const connection = {
     status: 'ok',

--- a/src/disconnect.test.ts
+++ b/src/disconnect.test.ts
@@ -22,6 +22,22 @@ test('should call quit on redis client', async (t) => {
   t.is(connection.redisClient, null)
 })
 
+test('should handle that quit throws even though client reports isOpen', async (t) => {
+  const redisClient = {
+    quit: sinon.stub().throws('Error'),
+    isOpen: true,
+  }
+  const connection = {
+    status: 'ok',
+    redisClient: redisClient,
+  } as unknown as Connection
+
+  await disconnect(connection)
+
+  t.is(redisClient.quit.callCount, 1)
+  t.is(connection.redisClient, null)
+})
+
 test('should not call quit on redis client when the client is already closed', async (t) => {
   const redisClient = {
     quit: sinon.stub().resolves(),

--- a/src/disconnect.test.ts
+++ b/src/disconnect.test.ts
@@ -9,6 +9,7 @@ import disconnect from './disconnect.js'
 test('should call quit on redis client', async (t) => {
   const redisClient = {
     quit: sinon.stub().resolves(),
+    isOpen: true,
   }
   const connection = {
     status: 'ok',
@@ -18,6 +19,22 @@ test('should call quit on redis client', async (t) => {
   await disconnect(connection)
 
   t.is(redisClient.quit.callCount, 1)
+  t.is(connection.redisClient, null)
+})
+
+test('should not call quit on redis client when the client is already closed', async (t) => {
+  const redisClient = {
+    quit: sinon.stub().resolves(),
+    isOpen: false,
+  }
+  const connection = {
+    status: 'ok',
+    redisClient: redisClient,
+  } as unknown as Connection
+
+  await disconnect(connection)
+
+  t.is(redisClient.quit.callCount, 0)
   t.is(connection.redisClient, null)
 })
 

--- a/src/disconnect.ts
+++ b/src/disconnect.ts
@@ -4,11 +4,13 @@ import type { Connection } from './types.js'
 const debug = debugFn('integreat:transporter:redis')
 
 export default async function disconnect(
-  connection: Connection | null
+  connection: Connection | null,
 ): Promise<void> {
   if (connection && connection.status === 'ok' && connection.redisClient) {
-    debug('Disconnect Redis client')
-    await connection.redisClient.quit()
+    debug('Disconnect Redis client if still open')
+    if (connection.redisClient.isOpen) {
+      await connection.redisClient.quit()
+    }
     connection.redisClient = null
   }
 }

--- a/src/disconnect.ts
+++ b/src/disconnect.ts
@@ -1,4 +1,5 @@
 import debugFn from 'debug'
+import { setTimeout } from 'timers/promises'
 import type { Connection } from './types.js'
 
 const debug = debugFn('integreat:transporter:redis')
@@ -7,14 +8,31 @@ export default async function disconnect(
   connection: Connection | null,
 ): Promise<void> {
   if (connection && connection.status === 'ok' && connection.redisClient) {
-    debug('Disconnect Redis client if still open')
-    if (connection.redisClient.isOpen) {
+    debug(
+      `Disconnect Redis client if still ready [isOpen=${connection.redisClient.isOpen}, isReady=${connection.redisClient.isReady}]`,
+    )
+    if (connection.redisClient.isReady) {
+      debug('Attempting to disconnect Redis client calling redisClient.quit()')
       try {
-        await connection.redisClient.quit()
+        const timeoutMessage = 'redisClient.quit() timed out'
+        const result = await Promise.race([
+          connection.redisClient.quit(),
+          // TODO: Make this timeout configurable too maybe?
+          setTimeout(100, timeoutMessage),
+        ])
+        if (result === timeoutMessage) {
+          debug(
+            'Timed out while calling redisClient.quit(), the connection is already closed',
+          )
+        }
       } catch (error) {
-        debug('Failed to call redisClient.quit(), ignoring the error:', error)
+        debug(
+          'Failed to call redisClient.quit(), ignoring the error as the connection is already closed:',
+          error,
+        )
       }
     }
+    debug('Setting connection.redisClient to null')
     connection.redisClient = null
   }
 }

--- a/src/disconnect.ts
+++ b/src/disconnect.ts
@@ -9,7 +9,11 @@ export default async function disconnect(
   if (connection && connection.status === 'ok' && connection.redisClient) {
     debug('Disconnect Redis client if still open')
     if (connection.redisClient.isOpen) {
-      await connection.redisClient.quit()
+      try {
+        await connection.redisClient.quit()
+      } catch (error) {
+        debug('Failed to call redisClient.quit(), ignoring the error:', error)
+      }
     }
     connection.redisClient = null
   }

--- a/src/send/index.ts
+++ b/src/send/index.ts
@@ -60,6 +60,8 @@ export default async function send(
       return sendSet(client, generateIdFn, id, data, concurrency)
     case 'DELETE':
       return sendDel(client, generateIdFn, id, data)
+    case 'PING':
+      return await client.ping().then((data) => ({ status: 'ok', data }))
     default:
       return { status: 'badrequest', error: `Unknown action '${action.type}'` }
   }

--- a/src/tests/get.test.ts
+++ b/src/tests/get.test.ts
@@ -1,16 +1,14 @@
 import ava, { TestFn } from 'ava'
 import { createClient } from 'redis'
 import transporter from '../index.js'
-import FakeTimers from '@sinonjs/fake-timers'
 
-interface RedisAndClockContext {
+interface RedisContext {
   redisClient: ReturnType<typeof createClient>
-  clock: FakeTimers.InstalledClock
 }
 
 // Setup
 
-const test = ava as TestFn<RedisAndClockContext>
+const test = ava as TestFn<RedisContext>
 
 const redisData1 = [
   'title',
@@ -44,24 +42,25 @@ const redisData3 = [
 ]
 
 test.before(async (t) => {
-  const redisClient = createClient()
-  await redisClient.connect()
-  await redisClient.hSet('store:article:art1', redisData1)
-  await redisClient.hSet('store:article:art2', redisData2)
-  await redisClient.hSet('store:article:art3', redisData3)
-  t.context = { redisClient, clock: FakeTimers.install({ toFake: ['Date'] }) }
+  try {
+    const redisClient = createClient()
+    await redisClient.connect()
+    await redisClient.hSet('store:article:art1', redisData1)
+    await redisClient.hSet('store:article:art2', redisData2)
+    await redisClient.hSet('store:article:art3', redisData3)
+    t.context = { redisClient }
+  } catch (error) {
+    console.error('Something went wrong:', error)
+  }
 })
 
 test.after.always(async (t) => {
-  const { redisClient, clock } = t.context
+  const { redisClient } = t.context
   if (redisClient) {
     await redisClient.del('store:article:art1')
     await redisClient.del('store:article:art2')
     await redisClient.del('store:article:art3')
     await redisClient.quit()
-  }
-  if (clock) {
-    clock.uninstall()
   }
 })
 
@@ -100,78 +99,6 @@ test('should get data from redis service', async (t) => {
 
   t.is(ret.status, 'ok')
   t.deepEqual(ret.data, expectedData)
-})
-
-test('should be able to reconnect to Redis if the server has disconnected', async (t) => {
-  const options = {
-    prefix: 'store',
-    redis: {
-      uri: 'redis://localhost:6379',
-    },
-    connectionTimeout: 1,
-  }
-  const action1 = {
-    type: 'GET',
-    payload: {
-      type: 'article',
-      id: 'art1',
-    },
-    meta: {
-      options,
-    },
-  }
-  const action2 = {
-    type: 'GET',
-    payload: {
-      type: 'article',
-      id: 'art2',
-    },
-    meta: {
-      options,
-    },
-  }
-  const expectedData1 = {
-    id: 'art1',
-    title: 'Article 1',
-    description: 'The first article',
-    publishedAt: null,
-    author: { id: 'johnf', name: 'John F.' },
-  }
-  const expectedData2 = {
-    id: 'art2',
-    title: 'Article 2',
-    description: 'The second article',
-    publishedAt: '2023-11-18T09:14:44Z',
-    author: { id: 'lucyk', name: 'Lucy K.' },
-  }
-  const connection = await transporter.connect(options, null, null, emit)
-  const ret1 = await transporter.send(action1, connection)
-
-  const redisClient = connection?.redisClient as ReturnType<typeof createClient>
-  await redisClient.disconnect()
-
-  // Wait for the connection to expire which should trigger an attempt to
-  // disconnect (and client.quit() under the hood) and then reconnect on
-  // the next call to transporter.connect()
-  t.context.clock.tick(options.connectionTimeout + 1)
-  t.context.clock.uninstall()
-
-  // Call transporter.connect(), with the existing connection as a parameter,
-  // to emulate the call to connection.connect() that happens in
-  // the sendToTransporter function in integreat "core"
-  // https://github.com/integreat-io/integreat/blob/main/src/service/utils/send.ts#L12
-  const newConnection = await transporter.connect(
-    options,
-    null,
-    connection,
-    emit,
-  )
-  const ret2 = await transporter.send(action2, newConnection)
-
-  t.is(ret1.status, 'ok')
-  t.deepEqual(ret1.data, expectedData1)
-  t.is(ret2.status, 'ok')
-  t.deepEqual(ret2.data, expectedData2)
 })
 
 test('should get data with several ids', async (t) => {

--- a/src/tests/get.test.ts
+++ b/src/tests/get.test.ts
@@ -148,7 +148,7 @@ test('should be able to reconnect to Redis if the server has disconnected', asyn
   const ret1 = await transporter.send(action1, connection)
 
   const redisClient = connection?.redisClient as ReturnType<typeof createClient>
-  await redisClient.quit()
+  await redisClient.disconnect()
 
   // Wait for the connection to expire which should trigger an attempt to
   // disconnect (and client.quit() under the hood) and then reconnect on

--- a/src/tests/get.test.ts
+++ b/src/tests/get.test.ts
@@ -1,7 +1,7 @@
 import ava, { TestFn } from 'ava'
 import { createClient } from 'redis'
-
 import transporter from '../index.js'
+import { setTimeout } from 'timers/promises'
 
 interface RedisContext {
   redisClient: ReturnType<typeof createClient>
@@ -96,6 +96,77 @@ test('should get data from redis service', async (t) => {
 
   t.is(ret.status, 'ok')
   t.deepEqual(ret.data, expectedData)
+})
+
+test('should be able to reconnect to Redis if the server has disconnected', async (t) => {
+  const options = {
+    prefix: 'store',
+    redis: {
+      uri: 'redis://localhost:6379',
+    },
+    connectionTimeout: 5,
+  }
+  const action1 = {
+    type: 'GET',
+    payload: {
+      type: 'article',
+      id: 'art1',
+    },
+    meta: {
+      options,
+    },
+  }
+  const action2 = {
+    type: 'GET',
+    payload: {
+      type: 'article',
+      id: 'art2',
+    },
+    meta: {
+      options,
+    },
+  }
+  const expectedData1 = {
+    id: 'art1',
+    title: 'Article 1',
+    description: 'The first article',
+    publishedAt: null,
+    author: { id: 'johnf', name: 'John F.' },
+  }
+  const expectedData2 = {
+    id: 'art2',
+    title: 'Article 2',
+    description: 'The second article',
+    publishedAt: '2023-11-18T09:14:44Z',
+    author: { id: 'lucyk', name: 'Lucy K.' },
+  }
+  const connection = await transporter.connect(options, null, null, emit)
+  const ret1 = await transporter.send(action1, connection)
+
+  const redisClient = connection?.redisClient as ReturnType<typeof createClient>
+  await redisClient.quit()
+
+  // Wait for the connection to expire which should trigger an attempt to
+  // disconnect (and client.quit() under the hood) and then reconnect on
+  // the next call to transporter.connect()
+  await setTimeout(options.connectionTimeout + 1)
+
+  // Call transporter.connect(), with the existing connection as a parameter,
+  // to emulate the call to connection.connect() that happens in
+  // the sendToTransporter function in integreat "core"
+  // https://github.com/integreat-io/integreat/blob/main/src/service/utils/send.ts#L12
+  const newConnection = await transporter.connect(
+    options,
+    null,
+    connection,
+    emit,
+  )
+  const ret2 = await transporter.send(action2, newConnection)
+
+  t.is(ret1.status, 'ok')
+  t.deepEqual(ret1.data, expectedData1)
+  t.is(ret2.status, 'ok')
+  t.deepEqual(ret2.data, expectedData2)
 })
 
 test('should get data with several ids', async (t) => {

--- a/src/tests/reconnect.test.ts
+++ b/src/tests/reconnect.test.ts
@@ -1,0 +1,76 @@
+import FakeTimers from '@sinonjs/fake-timers'
+import test from 'ava'
+import Docker from 'dockerode'
+import { createClient } from 'redis'
+import transporter from '../index.js'
+
+const emit = () => undefined
+
+test.serial(
+  'should be able to reconnect to Redis if the server has disconnected',
+  async (t) => {
+    const clock = FakeTimers.install({ toFake: ['Date'], now: Date.now() })
+    // Create and connect the RedisClient
+    const redisClient = createClient()
+    await redisClient.connect()
+
+    const options = {
+      prefix: 'store',
+      redis: {
+        uri: 'redis://localhost:6380',
+      },
+      connectionTimeout: 1,
+    }
+
+    const pingAction = {
+      type: 'PING',
+      payload: {},
+      meta: {},
+    }
+    const connection = await transporter.connect(options, null, null, emit)
+    const firstActionResult = await transporter.send(pingAction, connection)
+
+    // Disconnect the Redis client from the network
+    const docker = new Docker({ socketPath: '/var/run/docker.sock' })
+    const networks: Docker.NetworkInspectInfo[] = await docker.listNetworks()
+    const network = networks.find(
+      (network) => network.Name === 'integreat-transporter-redis_reconnect',
+    )
+    t.truthy(network, 'Network not found')
+    const networkId = network?.Id ?? 'N/A'
+
+    await docker
+      .getNetwork(networkId)
+      .disconnect({ Container: 'reconnect-redis' })
+
+    // Wait for the connection to expire which should trigger an attempt to
+    // disconnect (and client.quit() or client.disconnect() under the hood)
+    // and then reconnect on the next call to transporter.connect()
+    clock.tick(options.connectionTimeout + 1)
+    clock.uninstall()
+
+    // Reconnect to the network after options.connectionTimeout + 2 ms
+    setTimeout(async () => {
+      await docker
+        .getNetwork(networkId)
+        .connect({ Container: 'reconnect-redis' })
+    }, options.connectionTimeout + 2)
+
+    // Call transporter.connect(), with the existing connection as a parameter,
+    // to emulate the call to connection.connect() that happens in
+    // the sendToTransporter function in integreat "core"
+    // https://github.com/integreat-io/integreat/blob/main/src/service/utils/send.ts#L12
+    const newConnection = await transporter.connect(
+      options,
+      null,
+      connection,
+      emit,
+    )
+    const secondActionResult = await transporter.send(pingAction, newConnection)
+
+    t.is(firstActionResult.status, 'ok')
+    t.deepEqual(firstActionResult.data, 'PONG')
+    t.is(secondActionResult.status, 'ok')
+    t.deepEqual(secondActionResult.data, 'PONG')
+  },
+)


### PR DESCRIPTION
Check that the connection is open before attempting to quit() it. This is to avoid getting a ClientClosedError when disconnect() is called from within connect() when the `isExpired()` check returns true.

> [!NOTE]  
> @simenflatby I made this a pull request against `main` in our fork for now, so you can review it.
> Will make a proper pull request against upstream later